### PR TITLE
we usually want to create volumes that are owned by root.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,6 @@ ONBUILD USER user
 ONBUILD RUN \
     if [ -f /opt/docker/extension/run.user.sh ]; then sh /opt/docker/extension/run.user.sh; fi && \
         if [ -d /opt/docker/extension/ssh_config ]; then ls -1 /opt/docker/extension/ssh_config | while read FILE; do cp /opt/docker/extension/ssh_config/${FILE} /home/user/.ssh/config.d/${FILE} && chmod 0600 /home/user/.ssh/config.d/${FILE%}; done; fi
-ONBUILD VOLUME /home/user
-ONBUILD VOLUME /opt/docker/workspace
+ONBUILD VOLUME /home
+ONBUILD VOLUME /opt/docker
 


### PR DESCRIPTION
if we have user owned content then we want the volume to be
the parent volume -- to preserve ownership